### PR TITLE
Add the ability to generate iCalendar files on the fly via new createCalendarEvent lambda

### DIFF
--- a/lambdas/.webpack/service/calendar.js
+++ b/lambdas/.webpack/service/calendar.js
@@ -1,0 +1,179 @@
+module.exports =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./calendar.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./calendar.ts":
+/*!*********************!*\
+  !*** ./calendar.ts ***!
+  \*********************/
+/*! exports provided: createEvent */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"createEvent\", function() { return createEvent; });\n/* harmony import */ var util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! util */ \"util\");\n/* harmony import */ var util__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(util__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var lodash__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! lodash */ \"lodash\");\n/* harmony import */ var lodash__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(lodash__WEBPACK_IMPORTED_MODULE_1__);\n/* harmony import */ var _middy_core__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @middy/core */ \"@middy/core\");\n/* harmony import */ var _middy_core__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_middy_core__WEBPACK_IMPORTED_MODULE_2__);\n/* harmony import */ var _middy_http_cors__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @middy/http-cors */ \"@middy/http-cors\");\n/* harmony import */ var _middy_http_cors__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_middy_http_cors__WEBPACK_IMPORTED_MODULE_3__);\n/* harmony import */ var _middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @middy/do-not-wait-for-empty-event-loop */ \"@middy/do-not-wait-for-empty-event-loop\");\n/* harmony import */ var _middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_4__);\n/* harmony import */ var _middy_http_error_handler__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! @middy/http-error-handler */ \"@middy/http-error-handler\");\n/* harmony import */ var _middy_http_error_handler__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_middy_http_error_handler__WEBPACK_IMPORTED_MODULE_5__);\n/* harmony import */ var ics__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ics */ \"ics\");\n/* harmony import */ var ics__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(ics__WEBPACK_IMPORTED_MODULE_6__);\n\n\n\n\n\n\n\nconst createICS = Object(util__WEBPACK_IMPORTED_MODULE_0__[\"promisify\"])(ics__WEBPACK_IMPORTED_MODULE_6__[\"createEvents\"]);\n\nconst dateToArray = (date, includeTime = false) => {\n  const d = [date.getFullYear(), date.getMonth() + 1, date.getDate()];\n  const t = [date.getHours(), date.getMinutes()];\n  return includeTime ? d.concat(t) : d;\n};\n\nfunction processEvent(event) {\n  return {\n    title: event.title,\n    description: event.description,\n    start: dateToArray(new Date(event.start)),\n    end: dateToArray(new Date(event.end || event.start)),\n    productId: 'code4puertorico/paravotar'\n  };\n}\n\nconst handler = async event => {\n  const body = JSON.parse(event.body);\n\n  const events = lodash__WEBPACK_IMPORTED_MODULE_1___default.a.get(body, 'events', []);\n\n  const ics = await createICS(events.map(processEvent));\n\n  try {\n    return {\n      statusCode: 200,\n      headers: {\n        'Content-Type': 'text/calendar',\n        'Content-Disposition': 'attachment; filename=paravotar.ics'\n      },\n      body: ics\n    };\n  } catch (e) {\n    return {\n      statusCode: 500,\n      body: JSON.stringify(e)\n    };\n  }\n};\n\nconst createEvent = _middy_core__WEBPACK_IMPORTED_MODULE_2___default()(handler).use(_middy_http_cors__WEBPACK_IMPORTED_MODULE_3___default()()).use(_middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_4___default()()).use(_middy_http_error_handler__WEBPACK_IMPORTED_MODULE_5___default()());\n\n//# sourceURL=webpack:///./calendar.ts?");
+
+/***/ }),
+
+/***/ "@middy/core":
+/*!******************************!*\
+  !*** external "@middy/core" ***!
+  \******************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/core\");\n\n//# sourceURL=webpack:///external_%22@middy/core%22?");
+
+/***/ }),
+
+/***/ "@middy/do-not-wait-for-empty-event-loop":
+/*!**********************************************************!*\
+  !*** external "@middy/do-not-wait-for-empty-event-loop" ***!
+  \**********************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/do-not-wait-for-empty-event-loop\");\n\n//# sourceURL=webpack:///external_%22@middy/do-not-wait-for-empty-event-loop%22?");
+
+/***/ }),
+
+/***/ "@middy/http-cors":
+/*!***********************************!*\
+  !*** external "@middy/http-cors" ***!
+  \***********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/http-cors\");\n\n//# sourceURL=webpack:///external_%22@middy/http-cors%22?");
+
+/***/ }),
+
+/***/ "@middy/http-error-handler":
+/*!********************************************!*\
+  !*** external "@middy/http-error-handler" ***!
+  \********************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/http-error-handler\");\n\n//# sourceURL=webpack:///external_%22@middy/http-error-handler%22?");
+
+/***/ }),
+
+/***/ "ics":
+/*!**********************!*\
+  !*** external "ics" ***!
+  \**********************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"ics\");\n\n//# sourceURL=webpack:///external_%22ics%22?");
+
+/***/ }),
+
+/***/ "lodash":
+/*!*************************!*\
+  !*** external "lodash" ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"lodash\");\n\n//# sourceURL=webpack:///external_%22lodash%22?");
+
+/***/ }),
+
+/***/ "util":
+/*!***********************!*\
+  !*** external "util" ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"util\");\n\n//# sourceURL=webpack:///external_%22util%22?");
+
+/***/ })
+
+/******/ });

--- a/lambdas/.webpack/service/voterStatus.js
+++ b/lambdas/.webpack/service/voterStatus.js
@@ -1,0 +1,223 @@
+module.exports =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./voterStatus.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./voterStatus.ts":
+/*!************************!*\
+  !*** ./voterStatus.ts ***!
+  \************************/
+/*! exports provided: getVoterStatus, consulta */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"getVoterStatus\", function() { return getVoterStatus; });\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"consulta\", function() { return consulta; });\n/* harmony import */ var chrome_aws_lambda__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! chrome-aws-lambda */ \"chrome-aws-lambda\");\n/* harmony import */ var chrome_aws_lambda__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(chrome_aws_lambda__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var puppeteer_core__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! puppeteer-core */ \"puppeteer-core\");\n/* harmony import */ var puppeteer_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(puppeteer_core__WEBPACK_IMPORTED_MODULE_1__);\n/* harmony import */ var lodash__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lodash */ \"lodash\");\n/* harmony import */ var lodash__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lodash__WEBPACK_IMPORTED_MODULE_2__);\n/* harmony import */ var _middy_core__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @middy/core */ \"@middy/core\");\n/* harmony import */ var _middy_core__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_middy_core__WEBPACK_IMPORTED_MODULE_3__);\n/* harmony import */ var _middy_http_cors__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @middy/http-cors */ \"@middy/http-cors\");\n/* harmony import */ var _middy_http_cors__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_middy_http_cors__WEBPACK_IMPORTED_MODULE_4__);\n/* harmony import */ var _middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! @middy/do-not-wait-for-empty-event-loop */ \"@middy/do-not-wait-for-empty-event-loop\");\n/* harmony import */ var _middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_5__);\n/* harmony import */ var _middy_http_error_handler__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! @middy/http-error-handler */ \"@middy/http-error-handler\");\n/* harmony import */ var _middy_http_error_handler__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(_middy_http_error_handler__WEBPACK_IMPORTED_MODULE_6__);\n/* harmony import */ var aws_sdk__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! aws-sdk */ \"aws-sdk\");\n/* harmony import */ var aws_sdk__WEBPACK_IMPORTED_MODULE_7___default = /*#__PURE__*/__webpack_require__.n(aws_sdk__WEBPACK_IMPORTED_MODULE_7__);\n/* harmony import */ var qs__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! qs */ \"qs\");\n/* harmony import */ var qs__WEBPACK_IMPORTED_MODULE_8___default = /*#__PURE__*/__webpack_require__.n(qs__WEBPACK_IMPORTED_MODULE_8__);\n/* harmony import */ var axios__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! axios */ \"axios\");\n/* harmony import */ var axios__WEBPACK_IMPORTED_MODULE_9___default = /*#__PURE__*/__webpack_require__.n(axios__WEBPACK_IMPORTED_MODULE_9__);\n/* harmony import */ var node_html_parser__WEBPACK_IMPORTED_MODULE_10__ = __webpack_require__(/*! node-html-parser */ \"node-html-parser\");\n/* harmony import */ var node_html_parser__WEBPACK_IMPORTED_MODULE_10___default = /*#__PURE__*/__webpack_require__.n(node_html_parser__WEBPACK_IMPORTED_MODULE_10__);\n\n\n\n\n\n\n\n\n\n\n\nconst S3 = new aws_sdk__WEBPACK_IMPORTED_MODULE_7___default.a.S3();\nconst ceeUrl = \"http://consulta.ceepur.org\";\nconst bucket = \"paravotar\";\nconst precintsFile = \"precints.json\";\nconst countiesFile = \"counties.json\";\nconst papeletasFile = \"papeletas.json\";\nconst folder = \"/papeletas/2016\";\n\nconst handler = async event => {\n  try {\n    const executablePath = await chrome_aws_lambda__WEBPACK_IMPORTED_MODULE_0___default.a.executablePath;\n    const browser = await puppeteer_core__WEBPACK_IMPORTED_MODULE_1___default.a.launch({\n      args: chrome_aws_lambda__WEBPACK_IMPORTED_MODULE_0___default.a.args,\n      executablePath\n    });\n\n    const voterId = lodash__WEBPACK_IMPORTED_MODULE_2___default.a.get(event, \"queryStringParameters.voterId\", null);\n\n    if (!voterId) {\n      return {\n        statusCode: 400,\n        body: JSON.stringify({\n          error: \"invalid or missing voterId\"\n        })\n      };\n    }\n\n    const page = await browser.newPage();\n    await page.goto(ceeUrl);\n    await page.evaluate(n => {\n      document.querySelector('input[name=\"txtNumElectoral\"]').value = n;\n    }, voterId);\n    await page.$eval('input[name=\"btnConsulta\"]', el => el.click());\n    await page.waitFor(2000);\n    const rawData = await page.evaluate(() => {\n      return Array.from(document.querySelector(\"#info\").children).reduce((acum, curr) => acum.concat(curr), []).map(t => t.innerText).reduce((acum, curr) => ({ ...acum,\n        [curr.split(\":\")[0]]: curr.split(\":\")[1].trim()\n      }), {});\n    });\n    const data = Object.keys(rawData).map(k => ({\n      [lodash__WEBPACK_IMPORTED_MODULE_2___default.a.camelCase(k)]: rawData[k]\n    })).reduce((acum, curr) => {\n      return { ...acum,\n        ...curr\n      };\n    }, {});\n    const precintos = JSON.parse((await S3.getObject({\n      Bucket: bucket,\n      Key: precintsFile,\n      ResponseContentType: \"application/json\"\n    }).promise()).Body.toString());\n    const counties = JSON.parse((await S3.getObject({\n      Bucket: bucket,\n      Key: countiesFile,\n      ResponseContentType: \"application/json\"\n    }).promise()).Body.toString());\n    const papeletas = JSON.parse((await S3.getObject({\n      Bucket: bucket,\n      Key: papeletasFile,\n      ResponseContentType: \"application/json\"\n    }).promise()).Body.toString());\n\n    const p = lodash__WEBPACK_IMPORTED_MODULE_2___default.a.get(precintos, data.precinto, null);\n\n    let legislativo = p.papeleta.split(\"/\");\n    legislativo = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(legislativo[legislativo.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n\n    let municipal = counties[lodash__WEBPACK_IMPORTED_MODULE_2___default.a.camelCase(p.pueblo)].split(\"/\");\n\n    municipal = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(municipal[municipal.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n    let estatal = papeletas[0].papeletaLink.split(\"/\");\n    estatal = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(estatal[estatal.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n    const payload = { ...data,\n      pueblo: p.pueblo,\n      papeletas: {\n        legislativo,\n        municipal,\n        estatal\n      }\n    };\n    return {\n      statusCode: 200,\n      body: JSON.stringify(payload, null, 2)\n    };\n  } catch (e) {\n    console.log(e);\n    return {\n      statusCode: 500,\n      body: JSON.stringify(e)\n    };\n  }\n};\n\nconst getVoterStatus = _middy_core__WEBPACK_IMPORTED_MODULE_3___default()(handler).use(_middy_http_cors__WEBPACK_IMPORTED_MODULE_4___default()()).use(_middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_5___default()()).use(_middy_http_error_handler__WEBPACK_IMPORTED_MODULE_6___default()());\n\nconst getConsulta = async event => {\n  const voterId = lodash__WEBPACK_IMPORTED_MODULE_2___default.a.get(event, \"queryStringParameters.voterId\", null);\n\n  if (!voterId) {\n    return {\n      statusCode: 400,\n      body: JSON.stringify({\n        error: \"invalid or missing voterId\"\n      })\n    };\n  }\n\n  const formURLFields = {\n    __EVENTTARGET: \"\",\n    __EVENTARGUMENT: \"\",\n    __VIEWSTATE: \"j8e9Ob/a0bGuyuMpEyF8NXnyvV13igDM7a2M5Kq0eXZZ7GF2wZHN66rB9tUtHjzluJd29d5Nx/Q8xPSonfTaxJZ4Xc72qbuiuhDF9pZcxtHC0SomzwyVFIxd/SNz/YKx\",\n    __VIEWSTATEGENERATOR: \"D331ABD5\",\n    __EVENTVALIDATION: \"IcbJ6MBc2CH2sWiUW2edrQ5IKWiYYHDIPAMPZZZteP2OdYiVeH40S/UQTGXAG6mYxZol/GsBtqkeOKXVYFsY4xg7BUJjk31QN0/1HQwJUeHH7t+fRYXZKjWOFWelJO4h56mtJS4js8c80KnMY/eZomzavt+J4bWW4Q7HJagvkOwge/E/yjogoPO3xeh2yX8R/5H6A71WMzY1Y+ICAT2t3jfJWum3jOpWY0a/I7ZMDs9flYk/07f4kpNd/J00/Wo5SPEmATld062Jde3jleuKLfadz1oMXKvZG0yLcrFUnBgIs6sDhhuLgCaHCzUiJ2HtlpGnZr4dJL0jgvCJS2szA78BzGKn2xZaEOjfTxIEWo2ZXUohXJg9ACUqy+/qQQg3wQg4lcmkBVlvKC+GK7wy5g==\",\n    txtNumElectoral: voterId,\n    btnConsulta: \"Buscar\",\n    txtNumeroElectoral: \"\",\n    txtFechaNacimiento: \"\",\n    txtNombreEvento: \"\",\n    txtFechaEvento: \"\",\n    txtPrecinto: \"\",\n    txtUnidad: \"\",\n    txtColegio: \"\",\n    txtEstatus: \"\",\n    txtPagina: \"\",\n    txtLinea: \"\",\n    txtCentro: \"\",\n    txtDireccion: \"\"\n  };\n  let resp;\n\n  try {\n    resp = await axios__WEBPACK_IMPORTED_MODULE_9___default()({\n      method: \"post\",\n      url: \"http://consulta.ceepur.org\",\n      data: qs__WEBPACK_IMPORTED_MODULE_8___default.a.stringify(formURLFields),\n      headers: {\n        \"Content-Type\": \"application/x-www-form-urlencoded;charset=utf-8\"\n      }\n    });\n  } catch (e) {\n    console.log(e);\n    return {\n      statusCode: 500,\n      body: \"Failed to fetch from consulta.ceepur.org\"\n    };\n  }\n\n  const root = Object(node_html_parser__WEBPACK_IMPORTED_MODULE_10__[\"parse\"])(resp.data);\n  const data = {\n    numeroElectoral: voterId,\n    precinto: lodash__WEBPACK_IMPORTED_MODULE_2___default.a.padStart(root.querySelector(\"#txtPrecinto\").rawAttributes.value, 3, \"0\"),\n    unidad: root.querySelector(\"#txtUnidad\").rawAttributes.value,\n    colegio: root.querySelector(\"#txtColegio\").rawAttributes.value,\n    pagina: root.querySelector(\"#txtPagina\").rawAttributes.value,\n    linea: root.querySelector(\"#txtLinea\").rawAttributes.value,\n    estatus: root.querySelector(\"#txtEstatus\").rawAttributes.value,\n    fechaDeNacimiento: root.querySelector(\"#txtFechaNacimiento\").rawAttributes.value,\n    centroDeVotacion: root.querySelector(\"#txtCentro\").rawAttributes.value,\n    direccion: root.querySelector(\"#txtDireccion\").text\n  };\n\n  if (!data.precinto) {\n    return {\n      statusCode: 404,\n      body: \"Voter Id not found\"\n    };\n  }\n\n  const precintos = JSON.parse((await S3.getObject({\n    Bucket: bucket,\n    Key: precintsFile,\n    ResponseContentType: \"application/json\"\n  }).promise()).Body.toString());\n  const counties = JSON.parse((await S3.getObject({\n    Bucket: bucket,\n    Key: countiesFile,\n    ResponseContentType: \"application/json\"\n  }).promise()).Body.toString());\n  const papeletas = JSON.parse((await S3.getObject({\n    Bucket: bucket,\n    Key: papeletasFile,\n    ResponseContentType: \"application/json\"\n  }).promise()).Body.toString());\n\n  const p = lodash__WEBPACK_IMPORTED_MODULE_2___default.a.get(precintos, data.precinto, null);\n\n  if (!p) {\n    return {\n      statusCode: 400,\n      body: \"Unable to find ballots for precint \" + data.precinto\n    };\n  }\n\n  let legislativo = p.papeleta.split(\"/\");\n  legislativo = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(legislativo[legislativo.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n\n  let municipal = counties[lodash__WEBPACK_IMPORTED_MODULE_2___default.a.camelCase(p.pueblo)].split(\"/\");\n\n  municipal = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(municipal[municipal.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n  let estatal = papeletas[0].papeletaLink.split(\"/\");\n  estatal = `${folder}/${lodash__WEBPACK_IMPORTED_MODULE_2___default.a.lowerCase(decodeURIComponent(estatal[estatal.length - 1].split(\".\").slice(0, -1).join(\".\"))).split(\" \").join(\"-\")}`;\n  const payload = { ...data,\n    pueblo: p.pueblo,\n    papeletas: {\n      legislativo,\n      municipal,\n      estatal\n    }\n  };\n  return {\n    statusCode: 200,\n    body: JSON.stringify(payload, null, 2)\n  };\n};\n\nconst consulta = _middy_core__WEBPACK_IMPORTED_MODULE_3___default()(getConsulta).use(_middy_http_cors__WEBPACK_IMPORTED_MODULE_4___default()()).use(_middy_do_not_wait_for_empty_event_loop__WEBPACK_IMPORTED_MODULE_5___default()()).use(_middy_http_error_handler__WEBPACK_IMPORTED_MODULE_6___default()());\n\n//# sourceURL=webpack:///./voterStatus.ts?");
+
+/***/ }),
+
+/***/ "@middy/core":
+/*!******************************!*\
+  !*** external "@middy/core" ***!
+  \******************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/core\");\n\n//# sourceURL=webpack:///external_%22@middy/core%22?");
+
+/***/ }),
+
+/***/ "@middy/do-not-wait-for-empty-event-loop":
+/*!**********************************************************!*\
+  !*** external "@middy/do-not-wait-for-empty-event-loop" ***!
+  \**********************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/do-not-wait-for-empty-event-loop\");\n\n//# sourceURL=webpack:///external_%22@middy/do-not-wait-for-empty-event-loop%22?");
+
+/***/ }),
+
+/***/ "@middy/http-cors":
+/*!***********************************!*\
+  !*** external "@middy/http-cors" ***!
+  \***********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/http-cors\");\n\n//# sourceURL=webpack:///external_%22@middy/http-cors%22?");
+
+/***/ }),
+
+/***/ "@middy/http-error-handler":
+/*!********************************************!*\
+  !*** external "@middy/http-error-handler" ***!
+  \********************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"@middy/http-error-handler\");\n\n//# sourceURL=webpack:///external_%22@middy/http-error-handler%22?");
+
+/***/ }),
+
+/***/ "aws-sdk":
+/*!**************************!*\
+  !*** external "aws-sdk" ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"aws-sdk\");\n\n//# sourceURL=webpack:///external_%22aws-sdk%22?");
+
+/***/ }),
+
+/***/ "axios":
+/*!************************!*\
+  !*** external "axios" ***!
+  \************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"axios\");\n\n//# sourceURL=webpack:///external_%22axios%22?");
+
+/***/ }),
+
+/***/ "chrome-aws-lambda":
+/*!************************************!*\
+  !*** external "chrome-aws-lambda" ***!
+  \************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"chrome-aws-lambda\");\n\n//# sourceURL=webpack:///external_%22chrome-aws-lambda%22?");
+
+/***/ }),
+
+/***/ "lodash":
+/*!*************************!*\
+  !*** external "lodash" ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"lodash\");\n\n//# sourceURL=webpack:///external_%22lodash%22?");
+
+/***/ }),
+
+/***/ "node-html-parser":
+/*!***********************************!*\
+  !*** external "node-html-parser" ***!
+  \***********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"node-html-parser\");\n\n//# sourceURL=webpack:///external_%22node-html-parser%22?");
+
+/***/ }),
+
+/***/ "puppeteer-core":
+/*!*********************************!*\
+  !*** external "puppeteer-core" ***!
+  \*********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"puppeteer-core\");\n\n//# sourceURL=webpack:///external_%22puppeteer-core%22?");
+
+/***/ }),
+
+/***/ "qs":
+/*!*********************!*\
+  !*** external "qs" ***!
+  \*********************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("module.exports = require(\"qs\");\n\n//# sourceURL=webpack:///external_%22qs%22?");
+
+/***/ })
+
+/******/ });

--- a/lambdas/calendar.ts
+++ b/lambdas/calendar.ts
@@ -1,0 +1,55 @@
+import { promisify } from 'util';
+
+import _ from "lodash";
+import middy from "@middy/core";
+import cors from "@middy/http-cors";
+import doNotWaitForEmptyEventLoop from "@middy/do-not-wait-for-empty-event-loop";
+import httpErrorHandler from "@middy/http-error-handler";
+import { createEvents as icsCreateEvents, EventAttributes, DateArray } from 'ics';
+
+const createICS = promisify(icsCreateEvents);
+
+const dateToArray = (date: Date, includeTime: boolean = false): DateArray => {
+  const d: number[] = [date.getFullYear(), date.getMonth() + 1, date.getDate()];
+  const t: number[] = [date.getHours(), date.getMinutes()];
+
+  return <DateArray>(includeTime ? d.concat(t) : d);
+};
+
+function processEvent (event: any): EventAttributes {
+  return <EventAttributes>{
+    title: event.title,
+    description: event.description,
+    start: dateToArray(new Date(event.start)),
+    end: dateToArray(new Date(event.end || event.start)),
+    productId: 'code4puertorico/paravotar',
+  };
+}
+
+const handler = async (event: any) => {
+  const body = JSON.parse(event.body);
+  const events = _.get(body, 'events', []);
+
+  const ics = await createICS(events.map(processEvent));
+
+  try {
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/calendar',
+        'Content-Disposition': 'attachment; filename=paravotar.ics'
+      },
+      body: ics
+    }
+  } catch (e) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify(e),
+    };
+  }
+};
+
+export const createEvent = middy(handler)
+  .use(cors())
+  .use(doNotWaitForEmptyEventLoop())
+  .use(httpErrorHandler());

--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -2290,17 +2290,13 @@
     "@types/aws-lambda": {
       "version": "8.10.46",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.46.tgz",
-      "integrity": "sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA=="
+      "integrity": "sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "@types/http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha512-4KCE/agIcoQ9bIfa4sBxbZdnORzRjIw8JNQPLfqoNv7wQl/8f8mRbW68Q8wBsQFoJkPUHGlQYZ9sqi5WpfGSEQ=="
     },
     "@types/lodash": {
       "version": "4.14.149",
@@ -2552,6 +2548,7 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2565,15 +2562,11 @@
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
       "dev": true
     },
-    "ajv-i18n": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-3.5.0.tgz",
-      "integrity": "sha512-IR8uhRH0La4DweKHqBOVeoNo2prJ3bowWzGtNS3uDvYv5wKLgH/WQsoh6gHPVxTWXCGr+R+6I5vXDSXGAYnNPA=="
-    },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "dev": true
     },
     "ansi": {
       "version": "0.3.1",
@@ -2799,11 +2792,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sdk": {
-      "version": "2.648.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.648.0.tgz",
-      "integrity": "sha512-b+PdZmCFvZBisqXEH68jO4xB30LrDHQMWrEX6MJoZaOlxPJfpOqRFUH3zsiAXF5Q2jTdjYLtS5bs3vcIwRzi3Q==",
+      "version": "2.735.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.735.0.tgz",
+      "integrity": "sha512-nu5Cz2YcjHv2kgqtxW/DO0lz4Yc8g+xSB0Lb7Dp5iBEfyWLGGnhn5u4ALeFO9UUxLuSieirT1BR18BWSWH/Hlg==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -2815,9 +2808,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
@@ -3123,14 +3116,6 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
-    },
-    "busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "requires": {
-        "dicer": "0.3.0"
-      }
     },
     "cacache": {
       "version": "12.0.4",
@@ -3547,11 +3532,6 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -3902,14 +3882,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
       }
     },
     "diff": {
@@ -4554,12 +4526,14 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5163,6 +5137,67 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ics": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-2.23.0.tgz",
+      "integrity": "sha512-eFq3+G4KobHdVcNTLPuqaUnNxwYgpOm7VeIGOh1LLw9ftvRHigNwk6jeA+Zv/WyEZGiK1QfVRuSnZZfvt/TmeQ==",
+      "requires": {
+        "@hapi/joi": "^17.1.1",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/formula": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+          "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+        },
+        "@hapi/hoek": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+          "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+        },
+        "@hapi/joi": {
+          "version": "17.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+          "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+          "requires": {
+            "@hapi/address": "^4.0.1",
+            "@hapi/formula": "^2.0.0",
+            "@hapi/hoek": "^9.0.0",
+            "@hapi/pinpoint": "^2.0.0",
+            "@hapi/topo": "^5.0.0"
+          }
+        },
+        "@hapi/pinpoint": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+          "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -5559,11 +5594,6 @@
       "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
       "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw=="
     },
-    "json-mask": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/json-mask/-/json-mask-0.3.9.tgz",
-      "integrity": "sha512-RRu7bf7vzOohKMrU5pD9+fROMltTegWj2trZlPNr7hXekptFGkOZo4S63Jdx2X1GR7IK6rEVvXkQKY+2TPs0PA=="
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5597,7 +5627,8 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -6289,26 +6320,6 @@
         }
       }
     },
-    "middy": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/middy/-/middy-0.28.5.tgz",
-      "integrity": "sha512-6z55crz+8O9aViAUZFPmqWbB8chaAGuFsc/7LroPihsPEe+H/1y7a10f0+APhPDoUQVclrk8UEDnq9CvvVuQQA==",
-      "requires": {
-        "@types/aws-lambda": "^8.10.19",
-        "@types/http-errors": "^1.6.1",
-        "ajv": "^6.9.1",
-        "ajv-i18n": "^3.4.0",
-        "ajv-keywords": "^3.4.0",
-        "busboy": "^0.3.1",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.7.1",
-        "json-mask": "^0.3.8",
-        "negotiator": "^0.6.1",
-        "once": "^1.4.0",
-        "qs": "^6.6.0",
-        "querystring": "^0.2.0"
-      }
-    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -6492,11 +6503,6 @@
         "fs2": "^0.3.4",
         "type": "^1.0.1"
       }
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.1",
@@ -8675,11 +8681,6 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -9429,6 +9430,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -11,6 +11,7 @@
     "aws-sdk": "^2.668.0",
     "axios": "^0.19.2",
     "chrome-aws-lambda": "^2.1.1",
+    "ics": "^2.23.0",
     "lodash": "^4.17.15",
     "node-html-parser": "^1.2.19",
     "puppeteer-core": "^2.1.1",

--- a/lambdas/serverless.yml
+++ b/lambdas/serverless.yml
@@ -71,6 +71,12 @@ package:
     - node_modules/puppeteer/.local-chromium/**
 
 functions:
+  createCalendarEvent:
+    handler: calendar.createEvent
+    events:
+      - http:
+          path: /calendarEvent
+          method: post
   getVoterStatus:
     handler: voterStatus.getVoterStatus
     memorySize: 1536MB


### PR DESCRIPTION
## Description

Añade la capacidad de generar iCalendar files con HTTP requests usando un lambda `calendar.ts#createEvent`

- añade nueva dependencia [`ics`](https://npmjs.im/ics) para generar iCalendar files
- añade un nuevo file `calendar.ts` con un nuevo lambda handler `createEvent` que toma un HTTP event y devuelve un archivo .ics descargable

## Additional Context

https://github.com/Code4PuertoRico/paravotar/issues/140

## Usage

Work in Progress, pero sería un `POST` request a un lambda en JSON con una propiedad `events` que describe cada evento en el `.ics` deseado.
